### PR TITLE
Fixes empty operation variables

### DIFF
--- a/src/main/java/org/eclipse/basyx/aas/factory/xml/AASXPackageExplorerCompatibilityHandler.java
+++ b/src/main/java/org/eclipse/basyx/aas/factory/xml/AASXPackageExplorerCompatibilityHandler.java
@@ -59,7 +59,8 @@ public class AASXPackageExplorerCompatibilityHandler {
 		} else if (xmlObject instanceof List) {
 			return handleInvalidVariableList((List<?>) xmlObject);
 		} else if (xmlObject instanceof Map) {
-			return handleInvalidVariableMap((Map<String, Object>) xmlObject);
+			Map<String, Object> map = (Map<String, Object>) xmlObject;
+			return map.isEmpty() ? map : handleInvalidVariableMap(map);
 		} else {
 			throw createUnexpectedObjectRuntimeException(xmlObject);
 		}


### PR DESCRIPTION
When an OpertionVariable in AASX is empty the converter throws an Exception. The generated aasx (using BaSyx Converter) looks OK.
```
<aas:operation>
    ...
    <aas:inoutputVariable/>
    ...
</aas:operation>
```